### PR TITLE
Change token id to reflect img_start token id

### DIFF
--- a/llava/llava_injection.py
+++ b/llava/llava_injection.py
@@ -224,7 +224,7 @@ def train_image_entire(
             cur_input_embeds = inputs_embeds[0]
             num_patches = cur_image_features.shape[0]
 
-            image_start_tokens = torch.where(cur_input_ids == 32001)[0]
+            image_start_tokens = torch.where(cur_input_ids == 32002)[0]
 
             image_start_token_pos = image_start_tokens.item()
             cur_image_features = image_features[0].to(device=cur_input_embeds.device)
@@ -300,7 +300,7 @@ def train_image_partial(
             cur_input_embeds = inputs_embeds[0]
             num_patches = cur_image_features.shape[0]
 
-            image_start_tokens = torch.where(cur_input_ids == 32001)[0]
+            image_start_tokens = torch.where(cur_input_ids == 32002)[0]
 
             image_start_token_pos = image_start_tokens.item()
             cur_image_features = image_features[0].to(device=cur_input_embeds.device)


### PR DESCRIPTION
The token id of the start of an image is 32002 not 32001 which is the value currently used by the repo.


Reference: https://huggingface.co/liuhaotian/LLaVA-7b-delta-v0/blob/82f087980bb352c3d69faac1fb60512576be9fa0/added_tokens.json#L4